### PR TITLE
Set late process priority

### DIFF
--- a/addons/debug_draw_cs/DebugDraw.cs
+++ b/addons/debug_draw_cs/DebugDraw.cs
@@ -276,6 +276,7 @@ public class DebugDraw : Node
 
     public override void _Ready()
     {
+        ProcessPriority = int.MaxValue;
         internalInstance.Ready();
     }
 


### PR DESCRIPTION
Hi! Thanks so much for this addon. It's the best thing out there. And even better than the GDScript addon.

### Issue

Debug rendering can lag by 1 frame, due to rendering being executed before user's debug draw calls.

The issue is easily solved by setting this addon's process priority to something really high, e.g. int.MaxValue.
From the documentation:
> Nodes whose process priority value is lower will have their processing callbacks executed first

Before, on the left, my debug lines at the character's feet lag behind by 1 frame. After, on the right, rendering is perfectly in sync with characters movement.

https://user-images.githubusercontent.com/24359130/115114556-495ef900-9f90-11eb-9f68-336467e99c75.mp4

Let me know what you think.
Thanks again for this addon.